### PR TITLE
Use the caching of packets

### DIFF
--- a/src/main/java/com/lunarclient/bukkitimpl/LunarClient.java
+++ b/src/main/java/com/lunarclient/bukkitimpl/LunarClient.java
@@ -41,6 +41,7 @@ public class LunarClient extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new LunarClientUserListener(this), this);
     }
 
+    // TODO: Better loading implementation?
     public void loadWaypoints() {
         // if we don't have waypoints, don't continue.
         if (!getConfig().contains("waypoints")) {

--- a/src/main/java/com/lunarclient/bukkitimpl/LunarClient.java
+++ b/src/main/java/com/lunarclient/bukkitimpl/LunarClient.java
@@ -26,12 +26,6 @@ public class LunarClient extends JavaPlugin {
     @Getter
     private LCPacketModSettings packetModSettings = null;
     
-    // TODO: We can acctually cache the packet to 
-    //  send allowing easier implemntation of the
-    //  waypoint's without creating tons of objects
-    @Getter
-    private final List<LCWaypoint> waypoints = new ArrayList<>();
-    
     @Getter
     private final List<LCPacketWaypointAdd> waypointPackets = new ArrayList<>();
 
@@ -49,7 +43,6 @@ public class LunarClient extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new LunarClientUserListener(this), this);
     }
 
-    // TODO: Better loading implementation?
     public void loadWaypoints() {
         // if we don't have waypoints, don't continue.
         if (!getConfig().contains("waypoints")) {
@@ -59,7 +52,7 @@ public class LunarClient extends JavaPlugin {
         // Get all the list of waypoints
         List<Map<?, ?>> maps = getConfig().getMapList("waypoints");
         for (Map<?, ?> map : maps) {
-            // Create the waypoint.
+            // Create the waypoint & waypoint packet.
             // This is super brittle, and could be done better most likely.
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 JsonObject object = new JsonParser().parse(String.valueOf(entry.getValue())).getAsJsonObject();
@@ -67,8 +60,10 @@ public class LunarClient extends JavaPlugin {
                 LCWaypoint waypoint = new LCWaypoint((String) object.get("name").getAsString(), (Integer) object.get("x").getAsInt(), (Integer) object.get("y").getAsInt(), (Integer) object.get("z").getAsInt(), (String)  LunarClientAPI.getInstance().getWorldIdentifier(Bukkit.getWorld(object.get("world").getAsString())), (Integer) object.get("color").getAsInt(), (Boolean) object.get("forced").getAsBoolean(), (Boolean) object.get("visible").getAsBoolean());
                 LCPacketWaypointAdd packet = new LCPacketWaypointAdd(waypoint.getName(), waypoint.getWorld(), waypoint.getColor(), waypoint.getX(), waypoint.getY(), waypoint.getZ(), waypoint.isForced(), waypoint.isVisible());
                 
-                waypoints.add(waypoint);
-                waypointPackets.add(packet); // cache the packet to be used later
+                // Here we cache the packet to be used when someone joins,
+                // before we used the api to send the "Waypoint" but that
+                // was creating more packets/objects then needed.
+                waypointPackets.add(packet);
             }
         }
     }

--- a/src/main/java/com/lunarclient/bukkitimpl/LunarClient.java
+++ b/src/main/java/com/lunarclient/bukkitimpl/LunarClient.java
@@ -3,6 +3,7 @@ package com.lunarclient.bukkitimpl;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.lunarclient.bukkitapi.LunarClientAPI;
+import com.lunarclient.bukkitapi.nethandler.shared.LCPacketWaypointAdd;
 import com.lunarclient.bukkitapi.nethandler.client.LCPacketModSettings;
 import com.lunarclient.bukkitapi.nethandler.client.obj.ModSettings;
 import com.lunarclient.bukkitapi.nethandler.client.obj.ServerRule;
@@ -30,6 +31,9 @@ public class LunarClient extends JavaPlugin {
     //  waypoint's without creating tons of objects
     @Getter
     private final List<LCWaypoint> waypoints = new ArrayList<>();
+    
+    @Getter
+    private final List<LCPacketWaypointAdd> waypointPackets = new ArrayList<>();
 
     @Override
     public void onEnable() {
@@ -61,7 +65,10 @@ public class LunarClient extends JavaPlugin {
                 JsonObject object = new JsonParser().parse(String.valueOf(entry.getValue())).getAsJsonObject();
 
                 LCWaypoint waypoint = new LCWaypoint((String) object.get("name").getAsString(), (Integer) object.get("x").getAsInt(), (Integer) object.get("y").getAsInt(), (Integer) object.get("z").getAsInt(), (String)  LunarClientAPI.getInstance().getWorldIdentifier(Bukkit.getWorld(object.get("world").getAsString())), (Integer) object.get("color").getAsInt(), (Boolean) object.get("forced").getAsBoolean(), (Boolean) object.get("visible").getAsBoolean());
+                LCPacketWaypointAdd packet = new LCPacketWaypointAdd(waypoint.getName(), waypoint.getWorld(), waypoint.getColor(), waypoint.getX(), waypoint.getY(), waypoint.getZ(), waypoint.isForced(), waypoint.isVisible());
+                
                 waypoints.add(waypoint);
+                waypointPackets.add(packet); // cache the packet to be used later
             }
         }
     }

--- a/src/main/java/com/lunarclient/bukkitimpl/LunarClient.java
+++ b/src/main/java/com/lunarclient/bukkitimpl/LunarClient.java
@@ -24,6 +24,10 @@ public class LunarClient extends JavaPlugin {
     private static LunarClient instance;
     @Getter
     private LCPacketModSettings packetModSettings = null;
+    
+    // TODO: We can acctually cache the packet to 
+    //  send allowing easier implemntation of the
+    //  waypoint's without creating tons of objects
     @Getter
     private final List<LCWaypoint> waypoints = new ArrayList<>();
 

--- a/src/main/java/com/lunarclient/bukkitimpl/listener/LunarClientUserListener.java
+++ b/src/main/java/com/lunarclient/bukkitimpl/listener/LunarClientUserListener.java
@@ -6,9 +6,11 @@ import com.lunarclient.bukkitapi.object.LCWaypoint;
 import com.lunarclient.bukkitapi.serverrule.LunarClientAPIServerRule;
 import com.lunarclient.bukkitimpl.LunarClient;
 import lombok.RequiredArgsConstructor;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+
 
 @RequiredArgsConstructor
 public class LunarClientUserListener implements Listener {
@@ -17,18 +19,18 @@ public class LunarClientUserListener implements Listener {
 
     @EventHandler
     public void onPlayerRegister(PlayerJoinEvent event) {
+       Player player = event.getPlayer(); 
+        
         // When the player connects, send them our disabled mods.
         if (client.getPacketModSettings() != null) {
-            LunarClientAPI.getInstance().sendPacket(event.getPlayer(), client.getPacketModSettings());
+            LunarClientAPI.getInstance().sendPacket(player, client.getPacketModSettings());
         }
 
-        LunarClientAPIServerRule.sendServerRule(event.getPlayer());
-
-        if (!client.getWaypoints().isEmpty()) {
-            for (LCWaypoint waypoint : client.getWaypoints()) {
-                LunarClientAPI.getInstance().sendWaypoint(event.getPlayer(), waypoint);
-            }
+        LunarClientAPIServerRule.sendServerRule(player);
+        
+        // Send our cached packets when they connect.
+        for (LCPacketWaypointAdd packet : client.getWaypointPackets()) {
+            LunarClientAPI.getInstance().sendPacket(player, packet);
         }
-
     }
 }


### PR DESCRIPTION
Before you guys were caching waypoints and on join sending a waypoint would create an extra object then needed, so i cleaned it up and changed to were it will send a packet instead of using the api method #sendWaypoint(player, waypoint), it makes little to no difference but still better then caching waypoints.